### PR TITLE
Hot Fix: endless loop upon entering corrupted input data 

### DIFF
--- a/decompressor.go
+++ b/decompressor.go
@@ -20,6 +20,15 @@ func NewDecompressor() (Decompressor, error) {
 	return Decompressor{dc}, err
 }
 
+// NewDecompressorWithExtendedDecompression returns a new Decompressor used to decompress data at any compression level and with any Mode.
+// maxDecompressionFactor customizes how much larger your output than your input may be. This is set to a sensible default,
+// however, it might need some tweaking if you have a huge compression factor. Usually, NewDecompressor should suffice.
+// Errors if out of memory. Allocates 32KiB.
+func NewDecompressorWithExtendedDecompression(maxDecompressionFactor int) (Decompressor, error) {
+	dc, err := native.NewDecompressorWithExtendedDecompression(maxDecompressionFactor)
+	return Decompressor{dc}, err
+}
+
 // DecompressZlib decompresses the given zlib data from in to out and returns out or an error if something went wrong.
 //
 // If you pass a buffer to out, the size of this buffer must exactly match the length of the decompressed data.

--- a/decompressor_test.go
+++ b/decompressor_test.go
@@ -5,6 +5,8 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
+	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -85,4 +87,24 @@ func TestDecompressZlib(t *testing.T) {
 		t.Error(err)
 	}
 	slicesEqual([]byte(shortString), out, t)
+}
+
+var (
+	deadlyCode = "789c7d90316f83301085f7fc0ac45cac3b1b63cc0685542c55a4264b1784825bd1024686284851fe7b8104c454c" +
+		"b8bdff7de9def6e3b6b3cf6db298dedc0b26f02384014858efb2af78ecb1573c224e24e92301e4919d158c0dd7e7" +
+		"9a40a5de765f39ed76aca2e6a364caf5a17cacdbe2a7dcd8c6ab5e9d790eafab49d2ce87ac4f308724a5c5c70553" +
+		"6bfe1b93f968fa214287570bcfc882c6034a0fc736bfde873f38f99aee666fccfb3ad0f043d4604122917dc1abdc" +
+		"c6178deaa81a8416d60afcfba9ae8293e2cf2a5536609753f04194881be106c1de6d2eec7058c9c3180cdfc87691" +
+		"f814505305c77796d9e66042e372dd2622ec001c143ff09bec7bea151f90c05f3e916cc22f57cc976f73fc74374"
+	comp, _ = hex.DecodeString(deadlyCode)
+)
+
+func TestDecompressWithDeadlyCode(t *testing.T) {
+	dc, _ := NewDecompressor()
+	defer dc.Close()
+	_, err := dc.DecompressZlib(comp, nil)
+	if err == nil || !strings.Contains(err.Error(), "maximum decompression factor") {
+		t.Fail()
+		return
+	}
 }

--- a/native/errors.go
+++ b/native/errors.go
@@ -11,6 +11,8 @@ var (
 	errorUnknown       = errors.New("libdeflate: native: unknown error code from c library")
 	errorShortOutput   = errors.New("libdeflate: native: buffer too long: decompressed to fewer bytes than expected, indicating possible error in decompression. Make sure your out buffer has the exact length of the decompressed data or pass nil for out")
 	errorAlreadyClosed = errors.New("libdeflate: native: (de-)compressor already closed. It must not be used anymore")
+	errorInsufficientDecompressionFactor = errors.New("libdeflate: native: your compressed data seems to be extraordinarily large when decompressed. " +
+		"However, this could also indicate corrupted data. The current maximum decompression factor does not allow for larger decompression, try to increase it")
 
 	// checked error (in native)
 	errorInsufficientSpace = errors.New("libdeflate: native: buffer too short. Retry with larger buffer")

--- a/v2/decompressor.go
+++ b/v2/decompressor.go
@@ -20,6 +20,15 @@ func NewDecompressor() (Decompressor, error) {
 	return Decompressor{dc}, err
 }
 
+// NewDecompressorWithExtendedDecompression returns a new Decompressor used to decompress data at any compression level and with any Mode.
+// maxDecompressionFactor customizes how much larger your output than your input may be. This is set to a sensible default,
+// however, it might need some tweaking if you have a huge compression factor. Usually, NewDecompressor should suffice.
+// Errors if out of memory. Allocates 32KiB.
+func NewDecompressorWithExtendedDecompression(maxDecompressionFactor int) (Decompressor, error) {
+	dc, err := native.NewDecompressorWithExtendedDecompression(maxDecompressionFactor)
+	return Decompressor{dc}, err
+}
+
 // DecompressZlib decompresses the given zlib data from in to out and returns the number of consumed bytes c
 // from 'in' and 'out' or an error if something went wrong.
 //

--- a/v2/decompressor_test.go
+++ b/v2/decompressor_test.go
@@ -5,6 +5,8 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
+	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -85,4 +87,24 @@ func TestDecompressZlib(t *testing.T) {
 		t.Error(err)
 	}
 	slicesEqual(shortString, out, t)
+}
+
+var (
+	deadlyCode = "789c7d90316f83301085f7fc0ac45cac3b1b63cc0685542c55a4264b1784825bd1024686284851fe7b8104c454c" +
+		"b8bdff7de9def6e3b6b3cf6db298dedc0b26f02384014858efb2af78ecb1573c224e24e92301e4919d158c0dd7e7" +
+		"9a40a5de765f39ed76aca2e6a364caf5a17cacdbe2a7dcd8c6ab5e9d790eafab49d2ce87ac4f308724a5c5c70553" +
+		"6bfe1b93f968fa214287570bcfc882c6034a0fc736bfde873f38f99aee666fccfb3ad0f043d4604122917dc1abdc" +
+		"c6178deaa81a8416d60afcfba9ae8293e2cf2a5536609753f04194881be106c1de6d2eec7058c9c3180cdfc87691" +
+		"f814505305c77796d9e66042e372dd2622ec001c143ff09bec7bea151f90c05f3e916cc22f57cc976f73fc74374"
+	comp, _ = hex.DecodeString(deadlyCode)
+)
+
+func TestDecompressWithDeadlyCode(t *testing.T) {
+	dc, _ := NewDecompressor()
+	defer dc.Close()
+	_, _, err := dc.Decompress(comp, nil, ModeZlib)
+	if err == nil || !strings.Contains(err.Error(), "maximum decompression factor") {
+		t.Fail()
+		return
+	}
 }

--- a/v2/native/decompressor.go
+++ b/v2/native/decompressor.go
@@ -16,16 +16,22 @@ import "unsafe"
 type Decompressor struct {
 	dc *C.decomp
 	isClosed bool
+	maxDecompressionFactor int
 }
 
-// NewDecompressor returns a new Decompressor or and error if out of memory
+// NewDecompressor returns a new Decompressor with maxDecompressionFactor = 30 or and error if out of memory
 func NewDecompressor() (*Decompressor, error) {
+	return NewDecompressorWithExtendedDecompression(30)
+}
+
+// NewDecompressorWithExtendedDecompression returns a new Decompressor with maxDecompressionFactor or and error if out of memory
+func NewDecompressorWithExtendedDecompression(maxDecompressionFactor int) (*Decompressor, error) {
 	dc := C.libdeflate_alloc_decompressor()
 	if C.isNull(unsafe.Pointer(dc)) == 1 {
 		return nil, errorOutOfMemory
 	}
 
-	return &Decompressor{dc, false}, nil
+	return &Decompressor{dc, false, maxDecompressionFactor}, nil
 }
 
 // Decompress decompresses the given data from in to out and returns out and an error if something went wrong.
@@ -48,16 +54,21 @@ func (dc *Decompressor) Decompress(in, out []byte, f decompress) (int, []byte, e
 
 	cons := 0
 	n := 0
-	inc := 6
+	decompFactor := 6
 	err := errorInsufficientSpace
 	for err == errorInsufficientSpace {
-		out = make([]byte, len(in)*inc)
+		out = make([]byte, len(in)*decompFactor)
 		cons, n, err = dc.decompress(in, out, false, f)
-		if inc >= 16 {
-			inc += 3
+
+		if decompFactor > dc.maxDecompressionFactor {
+			return cons, out, errorInsufficientDecompressionFactor
+		}
+
+		if decompFactor >= 16 {
+			decompFactor += 3
 			continue
 		}
-		inc += 5
+		decompFactor += 5
 	}
 
 	return cons, out[:n], err

--- a/v2/native/errors.go
+++ b/v2/native/errors.go
@@ -11,6 +11,8 @@ var (
 	errorUnknown       = errors.New("libdeflate: native: unknown error code from c library")
 	errorShortOutput   = errors.New("libdeflate: native: buffer too long: decompressed to fewer bytes than expected, indicating possible error in decompression. Make sure your out buffer has the exact length of the decompressed data or pass nil for out")
 	errorAlreadyClosed = errors.New("libdeflate: native: (de-)compressor already closed. It must not be used anymore")
+	errorInsufficientDecompressionFactor = errors.New("libdeflate: native: your compressed data seems to be extraordinarily large when decompressed. " +
+		"However, this could also indicate corrupted data. The current maximum decompression factor does not allow for larger decompression, try to increase it")
 
 	// checked error (in native)
 	errorInsufficientSpace = errors.New("libdeflate: native: buffer too short. Retry with larger buffer")


### PR DESCRIPTION
The C library continuously reports insufficient space error when inputting the following array
```go
{ 0x78, 0x9c, 0x7d, 0x90, 0x31, 0x6f, 0x83, 0x30, 0x10, 0x85, 0xf7, 0xfc, 0xa, 0xc4, 0x5c, 0xac, 0x3b, 0x1b, 0x63, 0xcc, 0x6, 0x85, 0x54, 0x2c, 0x55, 0xa4, 0x26, 0x4b, 0x17, 0x84, 0x82, 0x5b, 0xd1, 0x2, 0x46, 0x86, 0x28, 0x48, 0x51, 0xfe, 0x7b, 0x81, 0x4, 0xc4, 0x54, 0xcb, 0x8b, 0xdf, 0xf7, 0xde, 0x9d, 0xef, 0x6e, 0x3b, 0x6b, 0x3c, 0xf6, 0xdb, 0x29, 0x8d, 0xed, 0xc0, 0xb2, 0x6f, 0x2, 0x38, 0x40, 0x14, 0x85, 0x8e, 0xfb, 0x2a, 0xf7, 0x8e, 0xcb, 0x15, 0x73, 0xc2, 0x24, 0xe2, 0x4e, 0x92, 0x30, 0x1e, 0x49, 0x19, 0xd1, 0x58, 0xc0, 0xdd, 0x7e, 0x79, 0xa4, 0xa, 0x5d, 0xe7, 0x65, 0xf3, 0x9e, 0xd7, 0x6a, 0xca, 0x2e, 0x6a, 0x36, 0x4c, 0xaf, 0x5a, 0x17, 0xca, 0xcd, 0xbe, 0x2a, 0x7d, 0xcd, 0x8c, 0x6a, 0xb5, 0xe9, 0xd7, 0x90, 0xea, 0xfa, 0xb4, 0x9d, 0x2c, 0xe8, 0x7a, 0xc4, 0xf3, 0x8, 0x72, 0x4a, 0x5c, 0x5c, 0x70, 0x55, 0x36, 0xbf, 0xe1, 0xb9, 0x3f, 0x96, 0x8f, 0xa2, 0x14, 0x28, 0x75, 0x70, 0xbc, 0xfc, 0x88, 0x2c, 0x60, 0x34, 0xa0, 0xfc, 0x73, 0x6b, 0xfd, 0xe8, 0x73, 0xf3, 0x8f, 0x99, 0xae, 0xe6, 0x66, 0xfc, 0xcf, 0xb3, 0xad, 0xf, 0x4, 0x3d, 0x46, 0x4, 0x12, 0x29, 0x17, 0xdc, 0x1a, 0xbd, 0xcc, 0x61, 0x78, 0xde, 0xaa, 0x81, 0xa8, 0x41, 0x6d, 0x60, 0xaf, 0xcf, 0xba, 0x9a, 0xe8, 0x29, 0x3e, 0x2c, 0xf2, 0xa5, 0x53, 0x66, 0x9, 0x75, 0x3f, 0x4, 0x19, 0x48, 0x81, 0xbe, 0x10, 0x6c, 0x1d, 0xe6, 0xd2, 0xee, 0xc7, 0x5, 0x8c, 0x9c, 0x31, 0x80, 0xcd, 0xfc, 0x87, 0x69, 0x1f, 0x81, 0x45, 0x5, 0x30, 0x5c, 0x77, 0x79, 0x6d, 0x9e, 0x66, 0x4, 0x2e, 0x37, 0x2d, 0xd2, 0x62, 0x2e, 0xc0, 0x1, 0xc1, 0x43, 0xff, 0x9, 0xbe, 0xc7, 0xbe, 0xa1, 0x51, 0xf9, 0xc, 0x5, 0xf3, 0xe9, 0x16, 0xcc, 0x22, 0xf5, 0x7c, 0xc9, 0x76, 0xf7, 0x3f, 0xc7, 0x43, 0x74 }
```
.

This PR hot fixes #13 for now. An issue in the c library will be created to figure out how to avoid this problem 