### PR TITLE
export errors

### DIFF
--- a/native/decompressing.go
+++ b/native/decompressing.go
@@ -47,12 +47,12 @@ func parseResult(r C.res) error {
 	case C.LIBDEFLATE_SUCCESS:
 		return nil
 	case C.LIBDEFLATE_BAD_DATA:
-		return errorBadData
+		return ErrorBadData
 	case C.LIBDEFLATE_SHORT_OUTPUT:
-		return errorShortOutput
+		return ErrorShortOutput
 	case C.LIBDEFLATE_INSUFFICIENT_SPACE:
-		return errorInsufficientSpace
+		return ErrorInsufficientSpace
 	default:
-		return errorUnknown
+		return ErrorUnknown
 	}
 }

--- a/native/decompressor.go
+++ b/native/decompressor.go
@@ -28,7 +28,7 @@ func NewDecompressor() (*Decompressor, error) {
 func NewDecompressorWithExtendedDecompression(maxDecompressionFactor int) (*Decompressor, error) {
 	dc := C.libdeflate_alloc_decompressor()
 	if C.isNull(unsafe.Pointer(dc)) == 1 {
-		return nil, errorOutOfMemory
+		return nil, ErrorOutOfMemory
 	}
 
 	return &Decompressor{dc, false, maxDecompressionFactor}, nil
@@ -40,10 +40,10 @@ func NewDecompressorWithExtendedDecompression(maxDecompressionFactor int) (*Deco
 // If you pass nil as out, this function will allocate a sufficient buffer and return it.
 func (dc *Decompressor) Decompress(in, out []byte, f decompress) ([]byte, error) {
 	if dc.isClosed {
-		panic(errorAlreadyClosed)
+		panic(ErrorAlreadyClosed)
 	}
 	if len(in) == 0 {
-		return out, errorNoInput
+		return out, ErrorNoInput
 	}
 
 	if out != nil {
@@ -53,13 +53,13 @@ func (dc *Decompressor) Decompress(in, out []byte, f decompress) ([]byte, error)
 
 	n := 0
 	decompFactor := 6
-	err := errorInsufficientSpace
-	for err == errorInsufficientSpace {
+	err := ErrorInsufficientSpace
+	for err == ErrorInsufficientSpace {
 		out = make([]byte, len(in)*decompFactor)
 		n, err = dc.decompress(in, out, false, f)
 
 		if decompFactor > dc.maxDecompressionFactor {
-			return out, errorInsufficientDecompressionFactor
+			return out, ErrorInsufficientDecompressionFactor
 		}
 
 		if decompFactor >= 16 {
@@ -95,7 +95,7 @@ func (dc *Decompressor) decompress(in, out []byte, fit bool, f decompress) (int,
 // Close frees the memory allocated by C objects
 func (dc *Decompressor) Close() {
 	if dc.isClosed {
-		panic(errorAlreadyClosed)
+		panic(ErrorAlreadyClosed)
 	}
 	C.libdeflate_free_decompressor(dc.dc)
 	dc.isClosed = true

--- a/native/decompressor_test.go
+++ b/native/decompressor_test.go
@@ -11,10 +11,10 @@ import (
 -----------------------*/
 
 func TestParseResult(t *testing.T) {
-	if err := parseResult(1); err != errorBadData {
+	if err := parseResult(1); err != ErrorBadData {
 		t.Fail()
 	}
-	if err := parseResult(200); err != errorUnknown {
+	if err := parseResult(200); err != ErrorUnknown {
 		t.Fail()
 	}
 	if err := parseResult(0); err != nil {

--- a/native/errors.go
+++ b/native/errors.go
@@ -3,17 +3,17 @@ package native
 import "errors"
 
 var (
-	errorOutOfMemory                     = errors.New("libdeflate: native: out of memory")
-	errorInvalidLevel                    = errors.New("libdeflate: native: illegal compression level")
-	errorShortBuffer                     = errors.New("libdeflate: native: short buffer")
-	errorNoInput                         = errors.New("libdeflate: native: empty input")
-	errorBadData                         = errors.New("libdeflate: native: bad data: data was corrupted, invalid or unsupported")
-	errorUnknown                         = errors.New("libdeflate: native: unknown error code from c library")
-	errorShortOutput                     = errors.New("libdeflate: native: buffer too long: decompressed to fewer bytes than expected, indicating possible error in decompression. Make sure your out buffer has the exact length of the decompressed data or pass nil for out")
-	errorAlreadyClosed                   = errors.New("libdeflate: native: (de-)compressor already closed. It must not be used anymore")
-	errorInsufficientDecompressionFactor = errors.New("libdeflate: native: your compressed data seems to be extraordinarily large when decompressed. " +
+	ErrorOutOfMemory                     = errors.New("libdeflate: native: out of memory")
+	ErrorInvalidLevel                    = errors.New("libdeflate: native: illegal compression level")
+	ErrorShortBuffer                     = errors.New("libdeflate: native: short buffer")
+	ErrorNoInput                         = errors.New("libdeflate: native: empty input")
+	ErrorBadData                         = errors.New("libdeflate: native: bad data: data was corrupted, invalid or unsupported")
+	ErrorUnknown                         = errors.New("libdeflate: native: unknown error code from c library")
+	ErrorShortOutput                     = errors.New("libdeflate: native: buffer too long: decompressed to fewer bytes than expected, indicating possible error in decompression. Make sure your out buffer has the exact length of the decompressed data or pass nil for out")
+	ErrorAlreadyClosed                   = errors.New("libdeflate: native: (de-)compressor already closed. It must not be used anymore")
+	ErrorInsufficientDecompressionFactor = errors.New("libdeflate: native: your compressed data seems to be extraordinarily large when decompressed. " +
 		"However, this could also indicate corrupted data. The current maximum decompression factor does not allow for larger decompression, try to increase it")
 
 	// checked error (in native)
-	errorInsufficientSpace = errors.New("libdeflate: native: buffer too short. Retry with larger buffer")
+	ErrorInsufficientSpace = errors.New("libdeflate: native: buffer too short. Retry with larger buffer")
 )


### PR DESCRIPTION
It would be nice to use errors.Is instead of strings.Contains(err.Error(), "bad data:").

My use case is decompressing potentially corrupt raw DEFLATE streams. The only error I care about exporting is ErrorBadData -it allows me to perform a binary search for uncorrupted bytes.

I figured other use cases might benefit from exposing all possible errors. Let me know if you'd prefer fewer errors exported, I'll update the PR.